### PR TITLE
make image required, and make background rendering conditional

### DIFF
--- a/cms/src/components/blocks/quote.json
+++ b/cms/src/components/blocks/quote.json
@@ -18,7 +18,7 @@
     "image": {
       "type": "media",
       "multiple": false,
-      "required": false,
+      "required": true,
       "allowedTypes": ["images"]
     },
     "background": {

--- a/frontend/src/components/QuoteHero.tsx
+++ b/frontend/src/components/QuoteHero.tsx
@@ -13,12 +13,14 @@ const QuoteHero = ({ ...data }) => {
 
   return (
     <Box>
-      <Image
-        alt={background.data.attributes.alternativeText}
-        height={150}
-        src={backgroundUrl}
-        width={200}
-      />
+      {background.data && (
+        <Image
+          alt={background.data.attributes.alternativeText}
+          height={150}
+          src={backgroundUrl}
+          width={200}
+        />
+      )}
       <Image
         alt={image.data.attributes.alternativeText}
         height={150}

--- a/frontend/src/components/QuoteHero.tsx
+++ b/frontend/src/components/QuoteHero.tsx
@@ -16,16 +16,16 @@ const QuoteHero = ({ ...data }) => {
       {background.data && (
         <Image
           alt={background.data.attributes.alternativeText}
-          height={150}
+          height={background.data.attributes.height}
           src={backgroundUrl}
-          width={200}
+          width={background.data.attributes.width}
         />
       )}
       <Image
         alt={image.data.attributes.alternativeText}
-        height={150}
+        height={image.data.attributes.height}
         src={imageUrl}
-        width={200}
+        width={image.data.attributes.width}
       />
       <Typography>{quote}</Typography>
       <Typography>{citation}</Typography>


### PR DESCRIPTION
This bugfix addresses the fact that the page broke if background image or image was not provided. made background image render only if there is one, and made image required, so there always is one.